### PR TITLE
Adds read:org scope to the list of required access token scopes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This project uses [yarn][] to manage dependencies.
 
 ### GitHub Token
 
-You'll need to to generate a [GitHub personal access token][] with `repo`
+You'll need to to generate a [GitHub personal access token][] with `repo` and `read:org` 
 scopes. Once generated, add it to a `.env` file:
 
 ```sh


### PR DESCRIPTION
@christoomey thanks for an excellent repo and talk!  After setting up a local instance of the project, though, I found that you also need the `read:org` scope on your personal access token to be able to view the user detail page.