### PR TITLE
Fix user display issue when no primary language

### DIFF
--- a/src/components/RepoStats.js
+++ b/src/components/RepoStats.js
@@ -6,7 +6,7 @@ import {Row} from './Flex';
 
 const RepoStats = ({repo}) => (
   <Row spaceBetween>
-    <Language language={repo.primaryLanguage} />
+    { repo.primaryLanguage && <Language language={repo.primaryLanguage} /> }
     <span>
       <ForkedIcon />
       {repo.forkCount}


### PR DESCRIPTION
Not all repos have a primaryLanguage causing certain user profiles to
appear blank.

<img width="923" alt="screen shot 2018-12-21 at 5 37 55 pm" src="https://user-images.githubusercontent.com/1781967/50366369-40d49000-0547-11e9-986c-eb8b4f18ec80.png">
